### PR TITLE
Refactor cursor-based game logic with shared interface

### DIFF
--- a/src/main/kotlin/model/CursorBasedGame.kt
+++ b/src/main/kotlin/model/CursorBasedGame.kt
@@ -1,0 +1,7 @@
+package model
+
+interface CursorBasedGame {
+    var cursorPosition: Float
+    fun updateCursorPosition(newPosition: Float)
+    fun isCursorAtLimit(): Boolean
+}

--- a/src/main/kotlin/response/ServerSocketMessage.kt
+++ b/src/main/kotlin/response/ServerSocketMessage.kt
@@ -84,11 +84,25 @@ sealed class ServerSocketMessage {
 
     @Serializable
     @SerialName("RoundEnded")
-    data class RoundEnded(
-        val cursorPosition: Float,
-        val correctAnswer: Int,
-        val winnerPlayerId: String?
-    ) : ServerSocketMessage()
+    sealed class RoundEnded : ServerSocketMessage() {
+        abstract val correctAnswer: Int
+        abstract val winnerPlayerId: String?
+
+        @Serializable
+        @SerialName("CursorRoundEnded")
+        data class CursorRoundEnded(
+            val cursorPosition: Float,
+            override val correctAnswer: Int,
+            override val winnerPlayerId: String?
+        ) : RoundEnded()
+
+        @Serializable
+        @SerialName("StandardRoundEnded")
+        data class StandardRoundEnded(
+            override val correctAnswer: Int,
+            override val winnerPlayerId: String?
+        ) : RoundEnded()
+    }
 
     @Serializable
     @SerialName("PlayerDisconnected")


### PR DESCRIPTION
Introduce `CursorBasedGame` interface to standardize cursor management across game types. Refactor `ResistanceGame` and `ResistToTimeGame` to implement the new interface, centralizing cursor updates and boundary checks. Update `ServerSocketMessage.RoundEnded` to support `CursorRoundEnded` and `StandardRoundEnded` for flexible round-ending scenarios.